### PR TITLE
Added platform check for terminal ANSI colours

### DIFF
--- a/src/pythle/cli.py
+++ b/src/pythle/cli.py
@@ -1,11 +1,15 @@
 import os
+import platform
 
 from pythle.guess import Guess
 from pythle.player_stats import PlayerStats
 
 """ DISPLAY SCORE COLOURS """
 
-os.system("color")  # enables ANSI colors in Windows terminal
+if platform.system() == "Windows":
+    # enables ANSI colors in Windows terminal
+    os.system("color")
+
 ansi_colours = {"green": "42", "yellow": "43", "blue": "44"}
 
 


### PR DESCRIPTION
### Description

When running on Linux apparently there is some spurious output that likely caused by ```os.system("color")``` (Thank you Nick!)

Since this is only required for Windows, added a condition which checks the platform.

### Related Issue

Hopefully fixes issue #39

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
